### PR TITLE
feat: add a few scripts for the deployment step

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,12 @@
 MNEMONIC="test test test test test test test test test test test junk"
 INFURA_PROJECT_ID=""
 ETHERSCAN_API_KEY=""
+
+POLYGONSCAN_API_KEY=""
+JSONRPC_HTTP_URL=""
+DAC_URL="http://cdk-validium-data-availability:8444"
+DAC_ADDRESS=""
+DEPLOYER_PRIVATE_KEY=""
+# for approve.js
+MATIC_TOKEN_ADDRESS=""
+CDK_VALIDIUM_ADDRESS=""

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 coverage.json
 .env
+wallets.txt
 cache
 build
 yarn.lock

--- a/deployment/helpers/approve.js
+++ b/deployment/helpers/approve.js
@@ -24,5 +24,7 @@ async function main() {
   );
 }
 
-main();
-
+// to prevent execution by accident on import
+if (require.main === module) {
+    main();
+}

--- a/deployment/helpers/approve.js
+++ b/deployment/helpers/approve.js
@@ -1,0 +1,28 @@
+const { ethers } = require("hardhat");
+require('dotenv').config();
+
+async function main() {
+  // Load provider
+  let provider = ethers.provider;
+
+  // Load signer
+  let signer = (await ethers.getSigners())[0];
+
+  const maticTokenFactory = await ethers.getContractFactory(
+    "ERC20PermitMock",
+    provider
+  );
+  maticTokenContract = maticTokenFactory.attach(
+    // From deployments/.../deploy_output.json maticTokenAddress
+    process.env.MATIC_TOKEN_ADDRESS
+  );
+  maticTokenContractWallet = maticTokenContract.connect(signer);
+  await maticTokenContractWallet.approve(
+  // From deployments/.../deploy_output.json cdkValidiumAddress
+    process.env.CDK_VALIDIUM_ADDRESS,
+    ethers.utils.parseEther("100.0")
+  );
+}
+
+main();
+

--- a/deployment/helpers/deployment-helpers.js
+++ b/deployment/helpers/deployment-helpers.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-await-in-loop, no-use-before-define, no-lonely-if, import/no-dynamic-require */
 /* eslint-disable no-console, no-inner-declarations, no-undef, import/no-unresolved */
 const { expect } = require('chai');
-const { ethers } = require('hardhat');
+const { ethers, network } = require("hardhat");
 
 const gasPriceKeylessDeployment = '100'; // 100 gweis
 
@@ -16,12 +16,13 @@ async function deployCDKValidiumDeployer(deployerAddress, signer) {
     const gasPrice = ethers.BigNumber.from(ethers.utils.parseUnits(gasPriceKeylessDeployment, 'gwei'));
     const to = '0x'; // bc deployment transaction, "to" is "0x"
     const tx = {
-        to,
-        nonce: 0,
-        value: 0,
-        gasLimit: gasLimit.toHexString(),
-        gasPrice: gasPrice.toHexString(),
-        data: deployTxCDKValidiumDeployer,
+      to,
+      chainId: network.config.chainId ?? 0, // some RPCs only support replay-protected txs (EIP-155)
+      nonce: 0,
+      value: 0,
+      gasLimit: gasLimit.toHexString(),
+      gasPrice: gasPrice.toHexString(),
+      data: deployTxCDKValidiumDeployer,
     };
 
     const signature = {

--- a/deployment/helpers/setup-committee.js
+++ b/deployment/helpers/setup-committee.js
@@ -1,0 +1,59 @@
+/* eslint-disable no-await-in-loop */
+const { expect } = require("chai");
+const ethers = require("ethers");
+require("dotenv").config();
+
+const deployOutput = require("./deploymentOutput/deploy_output.json");
+const dataCommitteeContractJson = require("./compiled-contracts/CDKDataCommittee.json");
+
+async function main() {
+  const dataCommitteeContractAddress = deployOutput["cdkDataCommitteeContract"];
+  if (
+    dataCommitteeContractAddress === undefined ||
+    dataCommitteeContractAddress === ""
+  ) {
+    throw new Error(`Missing DataCommitteeContract: ${deployOutput}`);
+  }
+  const dataCommitteeUrl = process.env.DAC_URL;
+  console.log("DAC_URL:", dataCommitteeUrl);
+  const dataCommitteeAddress = process.env.DAC_ADDRESS;
+  console.log("DAC_ADDRESS:", dataCommitteeAddress);
+  const JSONRPC_HTTP_URL = process.env.JSONRPC_HTTP_URL;
+  console.log("JSONRPC_HTTP_URL:", JSONRPC_HTTP_URL);
+  const currentProvider = new ethers.providers.JsonRpcProvider(
+    JSONRPC_HTTP_URL
+  );
+  const privateKey = process.env.DEPLOYER_PRIVATE_KEY;
+  // Load deployer
+  const deployer = new ethers.Wallet(privateKey, currentProvider);
+  console.log("Using pvtKey deployer with address: ", deployer.address);
+
+  const requiredAmountOfSignatures = 1;
+  const urls = [dataCommitteeUrl];
+  const addrsBytes = dataCommitteeAddress;
+  const dataCommitteeContract = new ethers.Contract(
+    dataCommitteeContractAddress,
+    dataCommitteeContractJson.abi,
+    deployer
+  );
+  const tx = await dataCommitteeContract.setupCommittee(
+    requiredAmountOfSignatures,
+    urls,
+    addrsBytes
+  );
+  console.log(`Committee seted up with ${dataCommitteeAddress}`);
+  console.log("Transaction hash:", tx.hash);
+  // Wait for receipt
+  const receipt = await tx.wait();
+  console.log("Transaction confirmed in block:", receipt.blockNumber);
+  const actualAmountOfmembers =
+    await dataCommitteeContract.getAmountOfMembers();
+  expect(actualAmountOfmembers.toNumber()).to.be.equal(urls.length);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/deployment/helpers/setup-committee.js
+++ b/deployment/helpers/setup-committee.js
@@ -8,10 +8,7 @@ const dataCommitteeContractJson = require("./compiled-contracts/CDKDataCommittee
 
 async function main() {
   const dataCommitteeContractAddress = deployOutput["cdkDataCommitteeContract"];
-  if (
-    dataCommitteeContractAddress === undefined ||
-    dataCommitteeContractAddress === ""
-  ) {
+  if (!dataCommitteeContractAddress) {
     throw new Error(`Missing DataCommitteeContract: ${deployOutput}`);
   }
   const dataCommitteeUrl = process.env.DAC_URL;

--- a/deployment/helpers/wallets.js
+++ b/deployment/helpers/wallets.js
@@ -1,0 +1,39 @@
+const ethers = require("ethers");
+const fs = require('fs');
+
+async function main() {
+  const password = process.argv[2];
+  
+  if (!password) {
+    console.error('Please provide a password as an argument.');
+    process.exit(1);
+  }
+
+  const arrayNames = [
+    "## Deployment Address",
+    "\\n\\n## Trusted sequencer",
+    "\\n\\n## Trusted aggregator",
+    "\\n\\n## DAC member",
+    "\\n\\n## Claim tx manager",
+  ];
+
+  let output = '';
+  for (let i = 0; i < arrayNames.length; i++) {
+    const wallet = ethers.Wallet.createRandom();
+    output += `${arrayNames[i]}\n`;
+    output += `Address: ${wallet.address}\n`;
+    output += `PrvKey: ${wallet.privateKey}\n`;
+    output += `mnemonic: "${wallet.mnemonic.phrase}"\n`;
+
+    const keystoreJson = await wallet.encrypt(password);
+    output += `keystore: ${keystoreJson}\n\n`;
+  }
+
+  fs.writeFileSync('wallets.txt', output);
+  console.log('Output written to wallets.txt');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,12 +1,13 @@
-require('dotenv').config();
-require('@nomiclabs/hardhat-waffle');
-require('hardhat-gas-reporter');
-require('solidity-coverage');
-require('@nomiclabs/hardhat-etherscan');
-require('@openzeppelin/hardhat-upgrades');
-require('hardhat-dependency-compiler');
+require("dotenv").config();
+require("@nomiclabs/hardhat-waffle");
+require("hardhat-gas-reporter");
+require("solidity-coverage");
+require("@nomiclabs/hardhat-etherscan");
+require("@openzeppelin/hardhat-upgrades");
+require("hardhat-dependency-compiler");
 
-const DEFAULT_MNEMONIC = 'test test test test test test test test test test test junk';
+const DEFAULT_MNEMONIC =
+  "test test test test test test test test test test test junk";
 
 /*
  * You need to export an object to set up your config
@@ -19,10 +20,10 @@ const DEFAULT_MNEMONIC = 'test test test test test test test test test test test
 module.exports = {
   dependencyCompiler: {
     paths: [
-      '@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol',
-      '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol',
-      '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol'
-    ]//,
+      "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol",
+      "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol",
+      "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol",
+    ], //,
     //keep: true
   },
   solidity: {
@@ -30,41 +31,41 @@ module.exports = {
       {
         version: "0.8.20",
         settings: {
-          evmVersion: 'paris',
+          evmVersion: "paris",
           optimizer: {
             enabled: true,
-            runs: 999999
-          }
-        }
+            runs: 999999,
+          },
+        },
       },
       {
         version: "0.6.11",
         settings: {
           optimizer: {
             enabled: true,
-            runs: 999999
-          }
-        }
+            runs: 999999,
+          },
+        },
       },
       {
         version: "0.5.12",
         settings: {
           optimizer: {
             enabled: true,
-            runs: 999999
-          }
-        }
+            runs: 999999,
+          },
+        },
       },
       {
         version: "0.5.16",
         settings: {
           optimizer: {
             enabled: true,
-            runs: 999999
-          }
-        }
-      }
-    ]
+            runs: 999999,
+          },
+        },
+      },
+    ],
   },
   networks: {
     mainnet: {
@@ -112,8 +113,18 @@ module.exports = {
         count: 20,
       },
     },
+    mumbai: {
+      url: `https://polygon-mumbai.infura.io/v3/${process.env.INFURA_PROJECT_ID}`,
+      accounts: {
+        mnemonic: process.env.MNEMONIC,
+        path: "m/44'/60'/0'/0",
+        initialIndex: 0,
+        count: 20,
+      },
+      chainId: 80001,
+    },
     localhost: {
-      url: 'http://127.0.0.1:8545',
+      url: "http://127.0.0.1:8545",
       accounts: {
         mnemonic: process.env.MNEMONIC || DEFAULT_MNEMONIC,
         path: "m/44'/60'/0'/0",
@@ -122,7 +133,7 @@ module.exports = {
       },
     },
     hardhat: {
-      initialDate: '0',
+      initialDate: "0",
       allowUnlimitedContractSize: true,
       accounts: {
         mnemonic: process.env.MNEMONIC || DEFAULT_MNEMONIC,
@@ -135,13 +146,14 @@ module.exports = {
   gasReporter: {
     enabled: !!process.env.REPORT_GAS,
     outputFile: process.env.REPORT_GAS_FILE ? "./gas_report.md" : null,
-    noColors: process.env.REPORT_GAS_FILE ? true : false
+    noColors: process.env.REPORT_GAS_FILE ? true : false,
   },
   etherscan: {
     apiKey: {
       goerli: `${process.env.ETHERSCAN_API_KEY}`,
       sepolia: `${process.env.ETHERSCAN_API_KEY}`,
-      mainnet: `${process.env.ETHERSCAN_API_KEY}`
+      mainnet: `${process.env.ETHERSCAN_API_KEY}`,
+      polygonMumbai: `${process.env.POLYGONSCAN_API_KEY}`,
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "verify:CDKValidium:mumbai": "npx hardhat run deployment/verifyContracts.js --network mumbai",
 
     "deploy:generate:wallets": "node deployment/helpers/wallets.js",
-    "deploy:approve:matic": "node deployment/helpers/aoorive.js"
+    "deploy:approve:matic": "node deployment/helpers/approve.js",
+    "deploy:setup:comittee": "node deployment/helpers/setup-committee.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -91,6 +91,17 @@
     "update:genesis": "node deployment/1_createGenesis.js && node deployment/1_createGenesis.js --test --input ../docker/scripts/deploy_parameters_docker.json --out ../docker/scripts/genesis_docker.json",
     "coverage": "npx hardhat coverage",
     "gas:report": "REPORT_GAS=true npx hardhat test",
-    "gas:report:file": "rm -f .openzeppelin/unknown-31337.json && REPORT_GAS=true REPORT_GAS_FILE=true npx hardhat test"
+    "gas:report:file": "rm -f .openzeppelin/unknown-31337.json && REPORT_GAS=true REPORT_GAS_FILE=true npx hardhat test",
+
+    "saveDeployment:mumbai": "mkdir -p deployments/mumbai_$(date +%s) && cp -r deployment/deploy_*.json deployments/mumbai_$(date +%s) && cp .openzeppelin/polygon-mumbai.json deployments/mumbai_$(date +%s) && cp deployment/genesis.json deployments/mumbai_$(date +%s) && mkdir -p deploymentOutput && cp deployment/deploy_*.json deploymentOutput",
+    "prepare:testnet:CDKValidium:mumbai": "npx hardhat run deployment/testnet/prepareTestnet.js --network mumbai",
+    "deploy:CDKValidium:mumbai": "node deployment/1_createGenesis.js && npx hardhat run deployment/3_deployContracts.js --network mumbai && npm run saveDeployment:mumbai",
+    "deploy:deployer:CDKValidium:mumbai": "npx hardhat run deployment/2_deployCDKValidiumDeployer.js --network mumbai",
+    "verify:deployer:CDKValidium:mumbai": "npx hardhat run deployment/verifyCDKValidiumDeployer.js --network mumbai",
+    "deploy:testnet:CDKValidium:mumbai": "npm run prepare:testnet:CDKValidium:mumbai && npm run deploy:CDKValidium:mumbai",
+    "verify:CDKValidium:mumbai": "npx hardhat run deployment/verifyContracts.js --network mumbai",
+
+    "deploy:generate:wallets": "node deployment/helpers/wallets.js",
+    "deploy:approve:matic": "node deployment/helpers/aoorive.js"
   }
 }


### PR DESCRIPTION
there are some setup that we usually do manually. write scripts to automate those. this will be used in our Ansible tasks later

- add a script for creating wallets
- add a script for approve the MATIC token
- add a script for set up the committee
- support Polygon Mumbai as the L1
- fix issue where some RPCs only support replay-protected txs (EIP-155)