### PR TITLE
add hardhat task: setSequencerUrlTask

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -5,6 +5,7 @@ require('solidity-coverage');
 require('@nomiclabs/hardhat-etherscan');
 require('@openzeppelin/hardhat-upgrades');
 require('hardhat-dependency-compiler');
+require("./tasks/setSequencerUrlTask");
 
 const DEFAULT_MNEMONIC = 'test test test test test test test test test test test junk';
 

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "deploy:generate:wallets": "node deployment/helpers/wallets.js",
     "deploy:approve:matic": "npx hardhat run deployment/helpers/approve.js --network",
     "deploy:setup:comittee": "npx hardhat run deployment/helpers/setup-committee.js --network",
+    "setSequencerUrl:sepolia": "npx hardhat setSequencerUrlTask --network sepolia",
     "deploy:merge:genesis": "node deployment/helpers/merge-genesis.js"
   }
 }

--- a/tasks/setSequencerUrlTask.js
+++ b/tasks/setSequencerUrlTask.js
@@ -1,0 +1,43 @@
+/* eslint-disable no-await-in-loop */
+/* eslint-disable no-console */
+/*
+ *Usage: npx hardhat setSequencerUrlTask --network <network> <url>
+ */
+const { task } = require("hardhat/config");
+const deployOutput = require("../deploymentOutput/deploy_output.json");
+
+async function setSequencerUrlTask(taskArgs, hre) {
+  const cdkContractAddress = deployOutput.cdkValidiumAddress;
+  if (!cdkContractAddress) {
+    throw new Error(`Missing cdkContractAddress: ${deployOutput}`);
+  }
+
+  // Load provider
+  const ethers = hre.ethers;
+  const { provider } = ethers;
+
+  // Load signer
+  const signer = (await ethers.getSigners())[0];
+
+  const cdkValidiumFactory = await ethers.getContractFactory(
+    "CDKValidium",
+    provider
+  );
+  const cdkValidiumContract = cdkValidiumFactory.attach(cdkContractAddress);
+  const cdkValidiumContractWallet = cdkValidiumContract.connect(signer);
+
+  const currentUrl = await cdkValidiumContract.trustedSequencerURL();
+  console.log(`current trustedSequencerUrl: ${currentUrl}\n`);
+
+  const tx = await cdkValidiumContractWallet.setTrustedSequencerURL(taskArgs.url);
+  console.log("Transaction hash:", tx.hash);
+  // Wait for receipt
+  const receipt = await tx.wait();
+  console.log("Transaction confirmed in block:", receipt.blockNumber);
+  const newUrl = await cdkValidiumContract.trustedSequencerURL();
+  console.log(`new trustedSequencerUrl: ${newUrl}`);
+}
+
+task("setSequencerUrlTask", "set trusted sequencer url")
+  .addPositionalParam("url")
+  .setAction(setSequencerUrlTask);


### PR DESCRIPTION
## Summary

to modify the CDK contract's `trustedSequencerURL`

## Test Plan
```
$ npm run setSequencerUrl:sepolia https://pangu.rpc.snapcha.in

> cdk-validium-contracts@0.0.1 setSequencerUrl:sepolia
> npx hardhat setSequencerUrlTask --network sepolia https://pangu.rpc.snapcha.in

current trustedSequencerUrl: <old url>

Transaction hash: 0xb157da1abd3e8a69e336aee185d9bb8e1bd518e06348d3644566144e1b8525e3
Transaction confirmed in block: 5533293
new trustedSequencerUrl: https://pangu.rpc.snapcha.in
```